### PR TITLE
Removing typings from postinstall scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   "scripts": {
     "start": "tsc && concurrently \"npm run tsc:w\" \"npm run lite\"",
     "lite": "lite-server",
-    "postinstall": "typings install",
     "tsc": "tsc",
     "tsc:w": "tsc -w",
     "typings": "typings"


### PR DESCRIPTION
Resolves #16, which causes users problems if they are not using the `typings` tool in their own project.